### PR TITLE
新規タブで開いた場合に動作しない問題の解消

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,11 +1,33 @@
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (
-    tab.url?.startsWith("https://www.nicovideo.jp/watch") &&
-    changeInfo.status === "complete"
-  ) {
-    chrome.tabs.sendMessage(tabId, {
-      message: "video_loaded",
+const isNicovideoTab = (tab: chrome.tabs.Tab): boolean => {
+  return !!tab.url?.startsWith("https://www.nicovideo.jp/watch");
+};
+
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  if (!isNicovideoTab(tab)) return;
+  if (changeInfo.status !== "complete") return;
+
+  try {
+    await chrome.tabs.sendMessage(tabId, {
+      message: "updateCompleted",
       url: tab.url,
     });
+  } catch (error) {
+    console.debug("sendMessage is failed");
+    console.debug(error);
+  }
+});
+
+chrome.tabs.onActivated.addListener(async (activateInfo) => {
+  const tab = await chrome.tabs.get(activateInfo.tabId);
+  if (!isNicovideoTab(tab)) return;
+
+  try {
+    await chrome.tabs.sendMessage(activateInfo.tabId, {
+      message: "activated",
+      url: tab.url,
+    });
+  } catch (error) {
+    console.debug("sendMessage is failed");
+    console.debug(error);
   }
 });

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -7,9 +7,14 @@ import {
 import { fetchNicoad, FetchNicoadResponse } from "./scripts/api/nicoad";
 import { CommentGraph } from "./scripts/graph";
 
-chrome.runtime.onMessage.addListener((request) => {
-  if (request.message === "video_loaded") {
-    drawGraph(request.url);
+chrome.runtime.onMessage.addListener(async (request) => {
+  switch (request.message) {
+    case "updateCompleted":
+    case "activated":
+      await drawGraph(request.url);
+      return;
+    default:
+      return;
   }
 });
 


### PR DESCRIPTION
バックグラウンドで起動中の別タブだとなぜかうまく動作しない。
`onActivated`イベント（タブを切り替えた場合に発火。同タブ内で更新した場合は発火しない。）を受け取った場合にも描画するよう修正。