### PR TITLE
fix(deps): update niconico api endpoint to new one

### DIFF
--- a/src/scripts/api/comment.ts
+++ b/src/scripts/api/comment.ts
@@ -105,7 +105,7 @@ export async function fetchVideoInfo(videoId: string): Promise<Response> {
 export async function fetchComments(
   videoInfo: FetchVideoInfoResponse
 ): Promise<Response> {
-  const uri = "https://nvcomment.nicovideo.jp/v1/threads";
+  const uri = 'https://nv-comment.nicovideo.jp/v1/threads';
   const body: FetchCommentsRequest = {
     params: videoInfo.data.comment.nvComment.params,
     threadKey: videoInfo.data.comment.nvComment.threadKey,


### PR DESCRIPTION
ニコニコ側の非公開APIが使えなくなっていた問題の対処。

FEで参照されていた新しいドメイン名に切り替えたところ正常動作できていそう。
詳細は洗えていないが、一旦これでhotfixを済ます。